### PR TITLE
added a warning if actual and predicted are not the same length in auc

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -3,6 +3,7 @@ Version 0.1.4 (2018-04-03)
 
 * Fixed bugs in percent_bias, ape, and mape. These functions did not properly
 handle negative values in the actual variable.
+* auc now throws a warning if you pass vectors of different lengths.
 
 Version 0.1.3 (2017-10-21)
 ------------------------------------------------------------------------------

--- a/R/binary_classification.R
+++ b/R/binary_classification.R
@@ -31,6 +31,10 @@ NULL
 #' predicted <- c(0.9, 0.8, 0.4, 0.5, 0.3, 0.2)
 #' auc(actual, predicted)
 auc <- function(actual, predicted) {
+    if (length(actual) != length(predicted)) {
+        msg <- "longer object length is not a multiple of shorter object length"
+        warning(msg)
+    }
     r <- rank(predicted)
     n_pos <- as.numeric(sum(actual == 1))
     n_neg <- length(actual) - n_pos

--- a/tests/testthat/test-binary_classification.R
+++ b/tests/testthat/test-binary_classification.R
@@ -5,6 +5,7 @@ test_that('area under ROC curve is calculated correctly', {
     expect_equal(auc(c(1,0,1,0,1),c(.9,.1,.8,.1,.7)), 1)
     expect_equal(auc(c(0,1,1,0),c(.2,.1,.3,.4)), 1/4)
     expect_equal(auc(c(1,1,1,1,0,0,0,0,0,0),0*(1:10)), 0.5)
+    expect_warning(auc(c(0, 1, 0), rnorm(2)), regexp = 'longer object')
 })
 
 test_that('log loss is calculated correctly', {


### PR DESCRIPTION
Responding to this [issue](https://github.com/mfrasco/Metrics/issues/13), I made auc throw a warning is the length of actual is not the same as the length of predicted.