### PR TITLE
Use log1p(x) instead of log(1+x)

### DIFF
--- a/R/regression.R
+++ b/R/regression.R
@@ -238,7 +238,7 @@ smape <- function(actual, predicted) {
 #' predicted <- c(0.9, 1.8, 2.5, 4.5, 5.0, 6.2)
 #' sle(actual, predicted)
 sle <- function(actual, predicted) {
-    return((log(1 + actual) - log(1 + predicted)) ^ 2)
+    return((log1p(actual) - log1p(predicted)) ^ 2)
 }
 
 #' Mean Squared Log Error


### PR DESCRIPTION
`log1p` is numerically accurate for small `x` with `1 + x == 1`:

```r
x = 1e-20
log(1 + x)
log1p(x)
```